### PR TITLE
fix: try to load SA name from values first

### DIFF
--- a/charts/aethos/Chart.yaml
+++ b/charts/aethos/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 0.1.0
 description: A Helm chart for Kubernetes
 name: aethos
 type: application
-version: 0.1.3
+version: 0.1.4
 maintainers:
   - name: xom4ek
     email: aleksei.lazarev@p2p.org

--- a/charts/aethos/templates/pvc.tpl
+++ b/charts/aethos/templates/pvc.tpl
@@ -12,7 +12,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
     {{- end}}
 spec:
-  storageClassName: oci-bv
+  storageClassName: {{ .Values.pvc.storageClassName }}
   accessModes:
     - ReadWriteOnce
   resources:

--- a/charts/aethos/templates/serviceaccount.tpl
+++ b/charts/aethos/templates/serviceaccount.tpl
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "aethos.fullname" . }}
+  name: {{ .Values.serviceAccount.name | default (include "aethos.fullname" .) }}
   labels:
     {{- include "aethos.labels" . | nindent 4 }}
     {{- with .Values.labels }}

--- a/charts/arpa/Chart.yaml
+++ b/charts/arpa/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 0.1.0
 description: A Helm chart for Kubernetes
 name: arpa
 type: application
-version: 0.1.2
+version: 0.1.3
 icon: https://avatars.githubusercontent.com/u/95603114?s=200&v=4
 maintainers:
   - name: xom4ek

--- a/charts/arpa/templates/serviceaccount.tpl
+++ b/charts/arpa/templates/serviceaccount.tpl
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "arpa.fullname" . }}
+  name: {{ .Values.serviceAccount.name | default (include "arpa.fullname" .) }}
   labels:
     {{- include "arpa.labels" . | nindent 4 }}
     {{- with .Values.labels }}

--- a/charts/k3/Chart.yaml
+++ b/charts/k3/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 0.1.0
 description: A Helm chart for Kubernetes
 name: k3
 type: application
-version: 0.1.2
+version: 0.1.3
 maintainers:
   - name: xom4ek
     email: aleksei.lazarev@p2p.org

--- a/charts/k3/templates/serviceaccount.tpl
+++ b/charts/k3/templates/serviceaccount.tpl
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "k3.fullname" . }}
+  name: {{ .Values.serviceAccount.name | default (include "k3.fullname" .) }}
   labels:
     {{- include "k3.labels" . | nindent 4 }}
     {{- with .Values.labels }}

--- a/charts/lagrange/Chart.yaml
+++ b/charts/lagrange/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 0.1.0
 description: A Helm chart for Kubernetes
 name: lagrange
 type: application
-version: 0.1.0
+version: 0.1.1
 maintainers:
   - name: xom4ek
     email: aleksei.lazarev@p2p.org

--- a/charts/lagrange/templates/serviceaccount.tpl
+++ b/charts/lagrange/templates/serviceaccount.tpl
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "lagrange.fullname" . }}
+  name: {{ .Values.serviceAccount.name | default (include "lagrange.fullname" .) }}
   labels:
     {{- include "lagrange.labels" . | nindent 4 }}
     {{- with .Values.labels }}

--- a/charts/openoracle/Chart.yaml
+++ b/charts/openoracle/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 0.1.0
 description: A Helm chart for Kubernetes
 name: openoracle
 type: application
-version: 0.1.2
+version: 0.1.3
 maintainers:
   - name: xom4ek
     email: aleksei.lazarev@p2p.org

--- a/charts/openoracle/templates/serviceaccount.tpl
+++ b/charts/openoracle/templates/serviceaccount.tpl
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "openoracle.fullname" . }}
+  name: {{ .Values.serviceAccount.name | default (include "openoracle.fullname" .) }}
   labels:
     {{- include "openoracle.labels" . | nindent 4 }}
     {{- with .Values.labels }}


### PR DESCRIPTION
`serviceAccount.name` should be used for both STS and the newly created SA.

For example, when `serviceAccount.name` is different than `chart.fullname` then STS will try to load non-existing SA.