### PR TITLE
feat(schema): Adjust values.schema.json and bump chart version

### DIFF
--- a/charts/arpa/Chart.yaml
+++ b/charts/arpa/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 0.1.0
 description: A Helm chart for Kubernetes
 name: arpa
 type: application
-version: 0.1.2
+version: 0.1.3
 icon: https://avatars.githubusercontent.com/u/95603114?s=200&v=4
 maintainers:
   - name: xom4ek

--- a/charts/arpa/values.schema.json
+++ b/charts/arpa/values.schema.json
@@ -166,7 +166,7 @@
                         "limits": {
                             "properties": {
                                 "cpu": {
-                                    "type": "integer"
+                                    "type": ["integer", "string"]
                                 },
                                 "memory": {
                                     "type": "string"
@@ -177,7 +177,7 @@
                         "requests": {
                             "properties": {
                                 "cpu": {
-                                    "type": "integer"
+                                    "type": ["integer", "string"]
                                 },
                                 "memory": {
                                     "type": "string"

--- a/charts/openoracle/Chart.yaml
+++ b/charts/openoracle/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 0.1.0
 description: A Helm chart for Kubernetes
 name: openoracle
 type: application
-version: 0.1.2
+version: 0.1.3
 maintainers:
   - name: xom4ek
     email: aleksei.lazarev@p2p.org

--- a/charts/openoracle/values.schema.json
+++ b/charts/openoracle/values.schema.json
@@ -122,7 +122,7 @@
                         "limits": {
                             "properties": {
                                 "cpu": {
-                                    "type": "integer"
+                                    "type": ["integer", "string"]
                                 },
                                 "memory": {
                                     "type": "string"
@@ -133,7 +133,7 @@
                         "requests": {
                             "properties": {
                                 "cpu": {
-                                    "type": "integer"
+                                    "type": ["integer", "string"]
                                 },
                                 "memory": {
                                     "type": "string"


### PR DESCRIPTION
The set values for the resource requests and limits are too high at the moment. It was only possible to use an integer which is still to high. That's why this merge requests enables the use of string values for the cpu limits and requests to make values like this valid:

```
  resources:
    limits:
      cpu: 500m
      memory: 4Gi
    requests:
      cpu: 250m
      memory: 4Gi
```